### PR TITLE
add maven plugin to attach the code to the generated jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,6 +130,19 @@
 				<artifactId>maven-resources-plugin</artifactId>
 				<version>2.2</version>
 			</plugin>
+			
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-source-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>attach-sources</id>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 	<reporting>


### PR DESCRIPTION
Without this plugin we can't see the code because the jar is downloaded only with byte codes from maven repository.
