### PR TITLE
Make version comparable

### DIFF
--- a/src/main/java/eu/bitwalker/useragentutils/Version.java
+++ b/src/main/java/eu/bitwalker/useragentutils/Version.java
@@ -120,11 +120,15 @@ public class Version implements Comparable<Version> {
 	        String[] otherVersionParts = other.version.split("\\.");
 
 	        for (int i = 0; i < Math.min(versionParts.length, otherVersionParts.length); i++) {
-	            int comparisonResult = versionParts[i].compareTo(otherVersionParts[i]);
-	            if (comparisonResult == 0) {
-	                continue;
+	            if (versionParts[i].length() == otherVersionParts[i].length()) {
+	        	int comparisonResult = versionParts[i].compareTo(otherVersionParts[i]);
+	        	if (comparisonResult == 0) {
+	        	    continue;
+	        	} else {
+	        	    return comparisonResult;
+	        	}
 	            } else {
-	                return comparisonResult;
+	        	return versionParts[i].length() > otherVersionParts[i].length() ? 1 : -1;
 	            }
 	        }
 

--- a/src/test/java/eu/bitwalker/useragentutils/VersionTest.java
+++ b/src/test/java/eu/bitwalker/useragentutils/VersionTest.java
@@ -12,5 +12,6 @@ public class VersionTest {
         assertTrue(new Version("7.0.1", "7", "0.1").compareTo(new Version("7.0", "7", "0")) > 0);
         assertTrue(new Version("7.0.1", "7", "0.1").compareTo(new Version("7.0.1", "7", "0.1")) == 0);
         assertTrue(new Version("7.0.a", "7", "0.a").compareTo(new Version("7.0.b", "7", "0.b")) < 0);
+        assertTrue(new Version("25.0", "25", "0").compareTo(new Version("3.1", "3", "1")) > 0);
     }
 }


### PR DESCRIPTION
Hi,

we have a use case where we want to support browser greater than a specified version, e.g. Firefox with a version greater or equals to 3.6. Therefore it would be useful to compare versions with each other.

With kind regards

Thorsten
