### PR TITLE
- Add agent string handling for Microsoft RSS Platform

### DIFF
--- a/src/main/java/eu/bitwalker/useragentutils/Browser.java
+++ b/src/main/java/eu/bitwalker/useragentutils/Browser.java
@@ -83,12 +83,7 @@ public enum Browser {
 		IEMOBILE9(		Manufacturer.MICROSOFT, Browser.IE, 123, "IE Mobile 9", new String[] { "IEMobile/9" }, null, BrowserType.MOBILE_BROWSER, RenderingEngine.TRIDENT, null), // before MSIE strings
 		IEMOBILE7(		Manufacturer.MICROSOFT, Browser.IE, 121, "IE Mobile 7", new String[] { "IEMobile 7" }, null, BrowserType.MOBILE_BROWSER, RenderingEngine.TRIDENT, null), // before MSIE strings
 		IEMOBILE6(		Manufacturer.MICROSOFT, Browser.IE, 120, "IE Mobile 6", new String[] { "IEMobile 6" }, null, BrowserType.MOBILE_BROWSER, RenderingEngine.TRIDENT, null), // before MSIE
-        IE11_RSS(       Manufacturer.MICROSOFT, Browser.IE, 96, "Internet Explorer 11", new String[] { "IE 11." }, null, BrowserType.RSS, RenderingEngine.TRIDENT, "IE (([0-9]+)\\.?([0-9]+))" ),   // RSS IE 11
-        IE10_RSS(       Manufacturer.MICROSOFT, Browser.IE, 93, "Internet Explorer 10", new String[] { "Windows-RSS-Platform/2.0 (MSIE 10" }, null, BrowserType.RSS, RenderingEngine.TRIDENT, null ),   // RSS IE 10
-        IE9_RSS(       Manufacturer.MICROSOFT, Browser.IE, 91, "Internet Explorer 9", new String[] { "Windows-RSS-Platform/2.0 (MSIE 9" }, null, BrowserType.RSS, RenderingEngine.TRIDENT, null ),   // RSS IE 9
-        IE8_RSS(       Manufacturer.MICROSOFT, Browser.IE, 81, "Internet Explorer 8", new String[] { "Windows-RSS-Platform/2.0 (MSIE 8" }, null, BrowserType.RSS, RenderingEngine.TRIDENT, null ),   // RSS IE 8
-        IE7_RSS(       Manufacturer.MICROSOFT, Browser.IE, 71, "Internet Explorer 7", new String[] { "Windows-RSS-Platform/1.0 (MSIE 7" }, null, BrowserType.RSS, RenderingEngine.TRIDENT, null ),   // RSS IE 7
-		IE11(			Manufacturer.MICROSOFT, Browser.IE, 95, "Internet Explorer 11", new String[] { "Trident/7" }, new String[] {"MSIE 7"}, BrowserType.WEB_BROWSER, RenderingEngine.TRIDENT, "Trident\\/7(?:\\.[0-9]*)?;.*rv:(([0-9]+)\\.?([0-9]+))" ),   // before Mozilla
+		IE11(			Manufacturer.MICROSOFT, Browser.IE, 95, "Internet Explorer 11", new String[] { "Trident/7", "IE 11." }, new String[] {"MSIE 7"}, BrowserType.WEB_BROWSER, RenderingEngine.TRIDENT, "(?:Trident\\/7|IE)(?:\\.[0-9]*;)?(?:.*rv:| )(([0-9]+)\\.?([0-9]+))" ),   // before Mozilla
 		IE10(			Manufacturer.MICROSOFT, Browser.IE, 92, "Internet Explorer 10", new String[] { "MSIE 10" }, null, BrowserType.WEB_BROWSER, RenderingEngine.TRIDENT, null ),   // before MSIE
 		IE9(			Manufacturer.MICROSOFT, Browser.IE, 90, "Internet Explorer 9", new String[] { "MSIE 9" }, null, BrowserType.WEB_BROWSER, RenderingEngine.TRIDENT, null ),   // before MSIE
 		IE8(			Manufacturer.MICROSOFT, Browser.IE, 80, "Internet Explorer 8", new String[] { "MSIE 8" }, null, BrowserType.WEB_BROWSER, RenderingEngine.TRIDENT, null ),   // before MSIE

--- a/src/main/java/eu/bitwalker/useragentutils/BrowserType.java
+++ b/src/main/java/eu/bitwalker/useragentutils/BrowserType.java
@@ -72,10 +72,6 @@ public enum BrowserType {
 	 * Application
 	 */
 	APP("Application"),
-    /**
-     * RSS Tool
-     */
-    RSS("Rss Tool"),
 	UNKNOWN("unknown");
 	
 	private String name;

--- a/src/test/java/eu/bitwalker/useragentutils/BrowserTest.java
+++ b/src/test/java/eu/bitwalker/useragentutils/BrowserTest.java
@@ -490,11 +490,11 @@ public class BrowserTest {
 		testAgents(ieMobile7, Browser.IEMOBILE7);
 		testAgents(ieMobile9, Browser.IEMOBILE9);
 		testAgents(ieMobile10, Browser.IEMOBILE10);
-        testAgents(ie7Rss, Browser.IE7_RSS);
-        testAgents(ie8Rss, Browser.IE8_RSS);
-        testAgents(ie9Rss, Browser.IE9_RSS);
-        testAgents(ie10Rss, Browser.IE10_RSS);
-		testAgents(ie11Rss, Browser.IE11_RSS);
+        testAgents(ie7Rss, Browser.IE7);
+        testAgents(ie8Rss, Browser.IE8);
+        testAgents(ie9Rss, Browser.IE9);
+        testAgents(ie10Rss, Browser.IE10);
+		testAgents(ie11Rss, Browser.IE11);
 		testAgents(lotusNotes, Browser.LOTUS_NOTES);
 		testAgents(lynxClient, Browser.LYNX);
 		testAgents(konqueror, Browser.KONQUEROR);


### PR DESCRIPTION
If a RSS Feed is parsed by MS IE Browsers, the agent string changes and will not be detected correctly.

Sample agent string (IE 11, RSS Platform): "Windows-RSS-Platform/2.0 (IE 11.0; Windows NT 6.1)"
