### PR TITLE
Modifications and package for exporting data to JSON

### DIFF
--- a/src/main/java/eu/bitwalker/useragentutils/Browser.java
+++ b/src/main/java/eu/bitwalker/useragentutils/Browser.java
@@ -1,25 +1,25 @@
 /*
-* Copyright (c) 2008-2014, Harald Walker (bitwalker.eu) and contributing developers 
+* Copyright (c) 2008-2014, Harald Walker (bitwalker.eu) and contributing developers
 * All rights reserved.
-* 
+*
 * Redistribution and use in source and binary forms, with or
 * without modification, are permitted provided that the
 * following conditions are met:
-* 
+*
 * * Redistributions of source code must retain the above
 * copyright notice, this list of conditions and the following
 * disclaimer.
-* 
+*
 * * Redistributions in binary form must reproduce the above
 * copyright notice, this list of conditions and the following
 * disclaimer in the documentation and/or other materials
 * provided with the distribution.
-* 
+*
 * * Neither the name of bitwalker nor the names of its
 * contributors may be used to endorse or promote products
 * derived from this software without specific prior written
 * permission.
-* 
+*
 * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
 * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
 * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
@@ -41,11 +41,13 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import net.sf.json.JSONObject;
+import net.sf.json.JSONArray;
 
 /**
  * Enum constants for most common browsers, including e-mail clients and bots.
  * @author harald
- * 
+ *
  */
 
 public enum Browser {
@@ -70,13 +72,13 @@ public enum Browser {
 	 */
 	IE( 			Manufacturer.MICROSOFT, null, 1, "Internet Explorer", new String[] { "MSIE", "Trident", "IE " }, null, BrowserType.WEB_BROWSER, RenderingEngine.TRIDENT, "MSIE (([\\d]+)\\.([\\w]+))" ), // before Mozilla
 		/**
-		 * Since version 7 Outlook Express is identifying itself. By detecting Outlook Express we can not 
+		 * Since version 7 Outlook Express is identifying itself. By detecting Outlook Express we can not
 		 * identify the Internet Explorer version which is probably used for the rendering.
 		 * Obviously this product is now called Windows Live Mail Desktop or just Windows Live Mail.
 		 */
 		OUTLOOK_EXPRESS7(	Manufacturer.MICROSOFT, Browser.IE, 110, "Windows Live Mail", new String[] {"Outlook-Express/7.0"}, null, BrowserType.EMAIL_CLIENT, RenderingEngine.TRIDENT, null), // before IE7, previously known as Outlook Express. First released in 2006, offered with different name later
 		/**
-		 * Since 2007 the mobile edition of Internet Explorer identifies itself as IEMobile in the user-agent. 
+		 * Since 2007 the mobile edition of Internet Explorer identifies itself as IEMobile in the user-agent.
 		 * If previous versions have to be detected, use the operating system information as well.
 		 */
 		IEMOBILE11(		Manufacturer.MICROSOFT, Browser.IE, 125, "IE Mobile 11", new String[] { "IEMobile/11" }, null, BrowserType.MOBILE_BROWSER, RenderingEngine.TRIDENT, null), // before MSIE strings
@@ -92,12 +94,12 @@ public enum Browser {
 		IE6(			Manufacturer.MICROSOFT, Browser.IE, 60, "Internet Explorer 6", new String[] { "MSIE 6" }, null, BrowserType.WEB_BROWSER, RenderingEngine.TRIDENT, null ),   // before MSIE
 		IE5_5(			Manufacturer.MICROSOFT, Browser.IE, 55, "Internet Explorer 5.5", new String[] { "MSIE 5.5" }, null, BrowserType.WEB_BROWSER, RenderingEngine.TRIDENT, null), // before MSIE
 		IE5(			Manufacturer.MICROSOFT, Browser.IE, 50, "Internet Explorer 5", new String[] { "MSIE 5" }, null, BrowserType.WEB_BROWSER, RenderingEngine.TRIDENT, null ), // before MSIE
-		
+
 	/**
 	 * Google Chrome browser
 	 */
 	CHROME( 		Manufacturer.GOOGLE, null, 1, "Chrome", new String[] { "Chrome", "CrMo", "CriOS" }, new String[] { "OPR/", "Web Preview" } , BrowserType.WEB_BROWSER, RenderingEngine.WEBKIT, "Chrome\\/(([0-9]+)\\.?([\\w]+)?(\\.[\\w]+)?(\\.[\\w]+)?)" ), // before Mozilla
-		CHROME_MOBILE( 	Manufacturer.GOOGLE, Browser.CHROME, 100, "Chrome Mobile", new String[] { "CrMo","CriOS", "Mobile Safari" }, null, BrowserType.MOBILE_BROWSER, RenderingEngine.WEBKIT, "(?:CriOS|CrMo|Chrome)\\/(([0-9]+)\\.?([\\w]+)?(\\.[\\w]+)?(\\.[\\w]+)?)" ), 
+		CHROME_MOBILE( 	Manufacturer.GOOGLE, Browser.CHROME, 100, "Chrome Mobile", new String[] { "CrMo","CriOS", "Mobile Safari" }, null, BrowserType.MOBILE_BROWSER, RenderingEngine.WEBKIT, "(?:CriOS|CrMo|Chrome)\\/(([0-9]+)\\.?([\\w]+)?(\\.[\\w]+)?(\\.[\\w]+)?)" ),
 		CHROME33( 		Manufacturer.GOOGLE, Browser.CHROME, 38, "Chrome 33", new String[] { "Chrome/33" }, new String[] { "OPR/", "Web Preview" }, BrowserType.WEB_BROWSER, RenderingEngine.WEBKIT, null ), // before Mozilla
 		CHROME32( 		Manufacturer.GOOGLE, Browser.CHROME, 37, "Chrome 32", new String[] { "Chrome/32" }, new String[] { "OPR/", "Web Preview" }, BrowserType.WEB_BROWSER, RenderingEngine.WEBKIT, null ), // before Mozilla
 		CHROME31( 		Manufacturer.GOOGLE, Browser.CHROME, 36, "Chrome 31", new String[] { "Chrome/31" }, new String[] { "OPR/", "Web Preview" }, BrowserType.WEB_BROWSER, RenderingEngine.WEBKIT, null ), // before Mozilla
@@ -124,8 +126,8 @@ public enum Browser {
 		CHROME10( 		Manufacturer.GOOGLE, Browser.CHROME, 15, "Chrome 10", new String[] { "Chrome/10" }, null, BrowserType.WEB_BROWSER, RenderingEngine.WEBKIT, null ), // before Mozilla
 		CHROME9( 		Manufacturer.GOOGLE, Browser.CHROME, 10, "Chrome 9", new String[] { "Chrome/9" }, null, BrowserType.WEB_BROWSER, RenderingEngine.WEBKIT, null ), // before Mozilla
 		CHROME8( 		Manufacturer.GOOGLE, Browser.CHROME, 5, "Chrome 8", new String[] { "Chrome/8" }, null, BrowserType.WEB_BROWSER, RenderingEngine.WEBKIT, null ), // before Mozilla
-			
-	OMNIWEB(		Manufacturer.OTHER, null, 2, "Omniweb", new String[] { "OmniWeb" }, null, BrowserType.WEB_BROWSER, RenderingEngine.WEBKIT, null), // 
+
+	OMNIWEB(		Manufacturer.OTHER, null, 2, "Omniweb", new String[] { "OmniWeb" }, null, BrowserType.WEB_BROWSER, RenderingEngine.WEBKIT, null), //
 
 	SAFARI(			Manufacturer.APPLE, null, 1, "Safari", new String[] { "Safari" }, new String[] { "OPR/", "Web Preview","Googlebot-Mobile" }, BrowserType.WEB_BROWSER, RenderingEngine.WEBKIT, "Version\\/(([0-9]+)\\.?([\\w]+)?(\\.[\\w]+)?)" ),  // before AppleWebKit
 		BLACKBERRY10( Manufacturer.BLACKBERRY, Browser.SAFARI, 10, "BlackBerry", new String[] { "BB10" }, null, BrowserType.MOBILE_BROWSER, RenderingEngine.WEBKIT, null),
@@ -142,22 +144,22 @@ public enum Browser {
 		OPERA18(		Manufacturer.OPERA, Browser.OPERA, 18, "Opera 18", new String[] { "OPR/18." }, null, BrowserType.WEB_BROWSER, RenderingEngine.WEBKIT, "OPR\\/(([\\d]+)\\.([\\w]+)?(\\.[\\w]+)?(\\.[\\w]+)?)"),
 		OPERA17(		Manufacturer.OPERA, Browser.OPERA, 17, "Opera 17", new String[] { "OPR/17." }, null, BrowserType.WEB_BROWSER, RenderingEngine.WEBKIT, "OPR\\/(([\\d]+)\\.([\\w]+)?(\\.[\\w]+)?(\\.[\\w]+)?)"),
 		OPERA16(		Manufacturer.OPERA, Browser.OPERA, 16, "Opera 16", new String[] { "OPR/16." }, null, BrowserType.WEB_BROWSER, RenderingEngine.WEBKIT, "OPR\\/(([\\d]+)\\.([\\w]+)?(\\.[\\w]+)?(\\.[\\w]+)?)"),
-		OPERA15(		Manufacturer.OPERA, Browser.OPERA, 15, "Opera 15", new String[] { "OPR/15." }, null, BrowserType.WEB_BROWSER, RenderingEngine.WEBKIT, "OPR\\/(([\\d]+)\\.([\\w]+)?(\\.[\\w]+)?(\\.[\\w]+)?)"),		
+		OPERA15(		Manufacturer.OPERA, Browser.OPERA, 15, "Opera 15", new String[] { "OPR/15." }, null, BrowserType.WEB_BROWSER, RenderingEngine.WEBKIT, "OPR\\/(([\\d]+)\\.([\\w]+)?(\\.[\\w]+)?(\\.[\\w]+)?)"),
 		OPERA12(		Manufacturer.OPERA, Browser.OPERA, 12, "Opera 12", new String[] { "Opera/12", "Version/12." }, null, BrowserType.WEB_BROWSER, RenderingEngine.PRESTO, "Version\\/(([\\d]+)\\.([\\w]+))"),
 		OPERA11(		Manufacturer.OPERA, Browser.OPERA, 11, "Opera 11", new String[] { "Version/11." }, null, BrowserType.WEB_BROWSER, RenderingEngine.PRESTO, "Version\\/(([\\d]+)\\.([\\w]+))"),
-		OPERA10(		Manufacturer.OPERA, Browser.OPERA, 10, "Opera 10", new String[] { "Opera/9.8" }, null, BrowserType.WEB_BROWSER, RenderingEngine.PRESTO, "Version\\/(([\\d]+)\\.([\\w]+))"),  
-		OPERA9(			Manufacturer.OPERA, Browser.OPERA, 5, "Opera 9", new String[] { "Opera/9" }, null, BrowserType.WEB_BROWSER, RenderingEngine.PRESTO, null),  
-	KONQUEROR(		Manufacturer.OTHER, null, 1, "Konqueror", new String[] { "Konqueror"}, null, BrowserType.WEB_BROWSER, RenderingEngine.KHTML, "Konqueror\\/(([0-9]+)\\.?([\\w]+)?(-[\\w]+)?)" ),  
-			
+		OPERA10(		Manufacturer.OPERA, Browser.OPERA, 10, "Opera 10", new String[] { "Opera/9.8" }, null, BrowserType.WEB_BROWSER, RenderingEngine.PRESTO, "Version\\/(([\\d]+)\\.([\\w]+))"),
+		OPERA9(			Manufacturer.OPERA, Browser.OPERA, 5, "Opera 9", new String[] { "Opera/9" }, null, BrowserType.WEB_BROWSER, RenderingEngine.PRESTO, null),
+	KONQUEROR(		Manufacturer.OTHER, null, 1, "Konqueror", new String[] { "Konqueror"}, null, BrowserType.WEB_BROWSER, RenderingEngine.KHTML, "Konqueror\\/(([0-9]+)\\.?([\\w]+)?(-[\\w]+)?)" ),
+
 	DOLFIN2( 		Manufacturer.SAMSUNG, null, 1, "Samsung Dolphin 2", new String[] { "Dolfin/2" }, null, BrowserType.MOBILE_BROWSER, RenderingEngine.WEBKIT, null ), // webkit based browser for the bada os
-	
+
 	/*
 	 * Apple WebKit compatible client. Can be a browser or an application with embedded browser using UIWebView.
 	 */
-	APPLE_WEB_KIT(	Manufacturer.APPLE, null, 50, "Apple WebKit", new String[] { "AppleWebKit" }, new String[] { "OPR/", "Web Preview", "Googlebot-Mobile" }, BrowserType.WEB_BROWSER, RenderingEngine.WEBKIT, null), // Microsoft Entrourage/Outlook 2010 also only identifies itself as AppleWebKit 
-		APPLE_ITUNES(	Manufacturer.APPLE, Browser.APPLE_WEB_KIT, 52, "iTunes", new String[] { "iTunes" }, null, BrowserType.APP, RenderingEngine.WEBKIT, null), // Microsoft Entrourage/Outlook 2010 also only identifies itself as AppleWebKit 
-		APPLE_APPSTORE(	Manufacturer.APPLE, Browser.APPLE_WEB_KIT, 53, "App Store", new String[] { "MacAppStore" }, null, BrowserType.APP, RenderingEngine.WEBKIT, null), // Microsoft Entrourage/Outlook 2010 also only identifies itself as AppleWebKit 
-		ADOBE_AIR(	Manufacturer.ADOBE, Browser.APPLE_WEB_KIT, 1, "Adobe AIR application", new String[] { "AdobeAIR" }, null, BrowserType.APP, RenderingEngine.WEBKIT, null), // Microsoft Entrourage/Outlook 2010 also only identifies itself as AppleWebKit 
+	APPLE_WEB_KIT(	Manufacturer.APPLE, null, 50, "Apple WebKit", new String[] { "AppleWebKit" }, new String[] { "OPR/", "Web Preview", "Googlebot-Mobile" }, BrowserType.WEB_BROWSER, RenderingEngine.WEBKIT, null), // Microsoft Entrourage/Outlook 2010 also only identifies itself as AppleWebKit
+		APPLE_ITUNES(	Manufacturer.APPLE, Browser.APPLE_WEB_KIT, 52, "iTunes", new String[] { "iTunes" }, null, BrowserType.APP, RenderingEngine.WEBKIT, null), // Microsoft Entrourage/Outlook 2010 also only identifies itself as AppleWebKit
+		APPLE_APPSTORE(	Manufacturer.APPLE, Browser.APPLE_WEB_KIT, 53, "App Store", new String[] { "MacAppStore" }, null, BrowserType.APP, RenderingEngine.WEBKIT, null), // Microsoft Entrourage/Outlook 2010 also only identifies itself as AppleWebKit
+		ADOBE_AIR(	Manufacturer.ADOBE, Browser.APPLE_WEB_KIT, 1, "Adobe AIR application", new String[] { "AdobeAIR" }, null, BrowserType.APP, RenderingEngine.WEBKIT, null), // Microsoft Entrourage/Outlook 2010 also only identifies itself as AppleWebKit
 
 	LOTUS_NOTES( 	Manufacturer.OTHER, null, 3, "Lotus Notes", new String[] { "Lotus-Notes" }, null, BrowserType.EMAIL_CLIENT, RenderingEngine.OTHER, "Lotus-Notes\\/(([\\d]+)\\.([\\w]+))"),  // before Mozilla
 
@@ -165,19 +167,19 @@ public enum Browser {
 		CAMINO2(		Manufacturer.OTHER, Browser.CAMINO, 17, "Camino 2", new String[] { "Camino/2" }, null, BrowserType.WEB_BROWSER, RenderingEngine.GECKO, null ),  // using Gecko Engine
 
 	FLOCK(			Manufacturer.OTHER, null, 4, "Flock", new String[]{"Flock"}, null, BrowserType.WEB_BROWSER, RenderingEngine.GECKO, "Flock\\/(([0-9]+)\\.?([\\w]+)?(\\.[\\w]+)?)"),
-		
+
 	FIREFOX(		Manufacturer.MOZILLA, null, 10, "Firefox", new String[] { "Firefox" }, new String[] {"ggpht.com"}, BrowserType.WEB_BROWSER, RenderingEngine.GECKO, "Firefox\\/(([0-9]+)\\.?([\\w]+)?(\\.[\\w]+)?(\\.[\\w]+)?)"),  // using Gecko Engine
 		FIREFOX3MOBILE(	Manufacturer.MOZILLA, Browser.FIREFOX, 31, "Firefox 3 Mobile", new String[] { "Firefox/3.5 Maemo" }, null, BrowserType.MOBILE_BROWSER, RenderingEngine.GECKO, null ),  // using Gecko Engine
 		FIREFOX_MOBILE(	Manufacturer.MOZILLA, Browser.FIREFOX, 200, "Firefox Mobile", new String[] { "Mobile" }, null, BrowserType.MOBILE_BROWSER, RenderingEngine.GECKO, null ),  // using Gecko Engine
 			FIREFOX_MOBILE23(Manufacturer.MOZILLA, FIREFOX_MOBILE, 223, "Firefox Mobile 23", new String[] { "Firefox/23" }, null, BrowserType.MOBILE_BROWSER, RenderingEngine.GECKO, null ),  // using Gecko Engine
-		FIREFOX30(		Manufacturer.MOZILLA, Browser.FIREFOX, 300, "Firefox 30", new String[] { "Firefox/30" }, null, BrowserType.WEB_BROWSER, RenderingEngine.GECKO, null ),  // using Gecko Engine		
-		FIREFOX29(		Manufacturer.MOZILLA, Browser.FIREFOX, 290, "Firefox 29", new String[] { "Firefox/29" }, null, BrowserType.WEB_BROWSER, RenderingEngine.GECKO, null ),  // using Gecko Engine		
-		FIREFOX28(		Manufacturer.MOZILLA, Browser.FIREFOX, 280, "Firefox 28", new String[] { "Firefox/28" }, null, BrowserType.WEB_BROWSER, RenderingEngine.GECKO, null ),  // using Gecko Engine		
-		FIREFOX27(		Manufacturer.MOZILLA, Browser.FIREFOX, 108, "Firefox 27", new String[] { "Firefox/27" }, null, BrowserType.WEB_BROWSER, RenderingEngine.GECKO, null ),  // using Gecko Engine		
-		FIREFOX26(		Manufacturer.MOZILLA, Browser.FIREFOX, 107, "Firefox 26", new String[] { "Firefox/26" }, null, BrowserType.WEB_BROWSER, RenderingEngine.GECKO, null ),  // using Gecko Engine		
-		FIREFOX25(		Manufacturer.MOZILLA, Browser.FIREFOX, 106, "Firefox 25", new String[] { "Firefox/25" }, null, BrowserType.WEB_BROWSER, RenderingEngine.GECKO, null ),  // using Gecko Engine		
-		FIREFOX24(		Manufacturer.MOZILLA, Browser.FIREFOX, 105, "Firefox 24", new String[] { "Firefox/24" }, null, BrowserType.WEB_BROWSER, RenderingEngine.GECKO, null ),  // using Gecko Engine		
-		FIREFOX23(		Manufacturer.MOZILLA, Browser.FIREFOX, 104, "Firefox 23", new String[] { "Firefox/23" }, null, BrowserType.WEB_BROWSER, RenderingEngine.GECKO, null ),  // using Gecko Engine		
+		FIREFOX30(		Manufacturer.MOZILLA, Browser.FIREFOX, 300, "Firefox 30", new String[] { "Firefox/30" }, null, BrowserType.WEB_BROWSER, RenderingEngine.GECKO, null ),  // using Gecko Engine
+		FIREFOX29(		Manufacturer.MOZILLA, Browser.FIREFOX, 290, "Firefox 29", new String[] { "Firefox/29" }, null, BrowserType.WEB_BROWSER, RenderingEngine.GECKO, null ),  // using Gecko Engine
+		FIREFOX28(		Manufacturer.MOZILLA, Browser.FIREFOX, 280, "Firefox 28", new String[] { "Firefox/28" }, null, BrowserType.WEB_BROWSER, RenderingEngine.GECKO, null ),  // using Gecko Engine
+		FIREFOX27(		Manufacturer.MOZILLA, Browser.FIREFOX, 108, "Firefox 27", new String[] { "Firefox/27" }, null, BrowserType.WEB_BROWSER, RenderingEngine.GECKO, null ),  // using Gecko Engine
+		FIREFOX26(		Manufacturer.MOZILLA, Browser.FIREFOX, 107, "Firefox 26", new String[] { "Firefox/26" }, null, BrowserType.WEB_BROWSER, RenderingEngine.GECKO, null ),  // using Gecko Engine
+		FIREFOX25(		Manufacturer.MOZILLA, Browser.FIREFOX, 106, "Firefox 25", new String[] { "Firefox/25" }, null, BrowserType.WEB_BROWSER, RenderingEngine.GECKO, null ),  // using Gecko Engine
+		FIREFOX24(		Manufacturer.MOZILLA, Browser.FIREFOX, 105, "Firefox 24", new String[] { "Firefox/24" }, null, BrowserType.WEB_BROWSER, RenderingEngine.GECKO, null ),  // using Gecko Engine
+		FIREFOX23(		Manufacturer.MOZILLA, Browser.FIREFOX, 104, "Firefox 23", new String[] { "Firefox/23" }, null, BrowserType.WEB_BROWSER, RenderingEngine.GECKO, null ),  // using Gecko Engine
 		FIREFOX22(		Manufacturer.MOZILLA, Browser.FIREFOX, 103, "Firefox 22", new String[] { "Firefox/22" }, null, BrowserType.WEB_BROWSER, RenderingEngine.GECKO, null ),  // using Gecko Engine
 		FIREFOX21(		Manufacturer.MOZILLA, Browser.FIREFOX, 102, "Firefox 21", new String[] { "Firefox/21" }, null, BrowserType.WEB_BROWSER, RenderingEngine.GECKO, null ),  // using Gecko Engine
 		FIREFOX20(		Manufacturer.MOZILLA, Browser.FIREFOX, 101, "Firefox 20", new String[] { "Firefox/20" }, null, BrowserType.WEB_BROWSER, RenderingEngine.GECKO, null ),  // using Gecko Engine
@@ -200,7 +202,7 @@ public enum Browser {
 		FIREFOX3(		Manufacturer.MOZILLA, Browser.FIREFOX, 30, "Firefox 3", new String[] { "Firefox/3" }, new String[] {"ggpht.com"}, BrowserType.WEB_BROWSER, RenderingEngine.GECKO, null ),  // using Gecko Engine
 		FIREFOX2(		Manufacturer.MOZILLA, Browser.FIREFOX, 20, "Firefox 2", new String[] { "Firefox/2" }, null, BrowserType.WEB_BROWSER, RenderingEngine.GECKO, null ),  // using Gecko Engine
 		FIREFOX1_5(		Manufacturer.MOZILLA, Browser.FIREFOX, 15, "Firefox 1.5", new String[] { "Firefox/1.5" }, null, BrowserType.WEB_BROWSER, RenderingEngine.GECKO, null ),  // using Gecko Engine
-		
+
 	/*
 	 * Thunderbird email client, based on the same Gecko engine Firefox is using.
 	 */
@@ -212,37 +214,37 @@ public enum Browser {
 		THUNDERBIRD7(  	Manufacturer.MOZILLA, Browser.THUNDERBIRD, 170, "Thunderbird 7", new String[] { "Thunderbird/7" }, null, BrowserType.EMAIL_CLIENT, RenderingEngine.GECKO, null ),  // using Gecko Engine
 		THUNDERBIRD6(  	Manufacturer.MOZILLA, Browser.THUNDERBIRD, 160, "Thunderbird 6", new String[] { "Thunderbird/6" }, null, BrowserType.EMAIL_CLIENT, RenderingEngine.GECKO, null ),  // using Gecko Engine
 		THUNDERBIRD3(  	Manufacturer.MOZILLA, Browser.THUNDERBIRD, 130, "Thunderbird 3", new String[] { "Thunderbird/3" }, null, BrowserType.EMAIL_CLIENT, RenderingEngine.GECKO, null ),  // using Gecko Engine
-		THUNDERBIRD2(  	Manufacturer.MOZILLA, Browser.THUNDERBIRD, 120, "Thunderbird 2", new String[] { "Thunderbird/2" }, null, BrowserType.EMAIL_CLIENT, RenderingEngine.GECKO, null ),  // using Gecko Engine	
-		
+		THUNDERBIRD2(  	Manufacturer.MOZILLA, Browser.THUNDERBIRD, 120, "Thunderbird 2", new String[] { "Thunderbird/2" }, null, BrowserType.EMAIL_CLIENT, RenderingEngine.GECKO, null ),  // using Gecko Engine
+
 	SEAMONKEY(		Manufacturer.OTHER, null, 15, "SeaMonkey", new String[]{"SeaMonkey"}, null, BrowserType.WEB_BROWSER, RenderingEngine.GECKO, "SeaMonkey\\/(([0-9]+)\\.?([\\w]+)?(\\.[\\w]+)?)"), // using Gecko Engine
-	
+
 	BOT(			Manufacturer.OTHER, null,12, "Robot/Spider", new String[] {"Googlebot", "Web Preview", "bot", "spider", "crawler", "Feedfetcher", "Slurp", "Twiceler", "Nutch", "BecomeBot"}, null, BrowserType.ROBOT, RenderingEngine.OTHER, null),
 	BOT_MOBILE( 	Manufacturer.OTHER, Browser.BOT, 20 , "Mobil Robot/Spider", new String[] {"Googlebot-Mobile"}, null, BrowserType.ROBOT, RenderingEngine.OTHER, null),
-	
+
 	MOZILLA(		Manufacturer.MOZILLA, null, 1, "Mozilla", new String[] { "Mozilla", "Moozilla" }, new String[] {"ggpht.com"}, BrowserType.WEB_BROWSER, RenderingEngine.OTHER, null), // rest of the mozilla browsers
-	
+
 	CFNETWORK(		Manufacturer.OTHER, null, 6, "CFNetwork", new String[] { "CFNetwork" }, null, BrowserType.UNKNOWN, RenderingEngine.OTHER, null ), // Mac OS X cocoa library
-	
+
 	EUDORA(			Manufacturer.OTHER, null, 7, "Eudora", new String[] { "Eudora", "EUDORA" }, null, BrowserType.EMAIL_CLIENT, RenderingEngine.OTHER, null ),  // email client by Qualcomm
-	
+
 	POCOMAIL(		Manufacturer.OTHER, null, 8, "PocoMail", new String[] { "PocoMail" }, null, BrowserType.EMAIL_CLIENT, RenderingEngine.OTHER, null ),
-	
+
 	THEBAT(			Manufacturer.OTHER, null, 9, "The Bat!", new String[]{"The Bat"}, null, BrowserType.EMAIL_CLIENT, RenderingEngine.OTHER, null), // Email Client
-	
+
 	NETFRONT(		Manufacturer.OTHER, null, 10, "NetFront", new String[]{"NetFront"}, null, BrowserType.MOBILE_BROWSER, RenderingEngine.OTHER, null), // mobile device browser
-	
+
 	EVOLUTION(		Manufacturer.OTHER, null, 11, "Evolution", new String[]{"CamelHttpStream"}, null, BrowserType.EMAIL_CLIENT, RenderingEngine.OTHER, null), // http://www.go-evolution.org/Camel.Stream
-    
+
 	LYNX(			Manufacturer.OTHER, null, 13, "Lynx", new String[]{"Lynx"}, null, BrowserType.TEXT_BROWSER, RenderingEngine.OTHER, "Lynx\\/(([0-9]+)\\.([\\d]+)\\.?([\\w-+]+)?\\.?([\\w-+]+)?)"),
-    
+
 	DOWNLOAD(   	Manufacturer.OTHER, null, 16, "Downloading Tool", new String[]{"cURL","wget", "ggpht.com", "Apache-HttpClient"}, null, BrowserType.TOOL, RenderingEngine.OTHER, null),
-    
+
 	UNKNOWN(		Manufacturer.OTHER, null, 14, "Unknown", new String[0], null, BrowserType.UNKNOWN, RenderingEngine.OTHER, null ),
 	@Deprecated
-	APPLE_MAIL(		Manufacturer.APPLE, null, 51, "Apple Mail", new String[0], null, BrowserType.EMAIL_CLIENT, RenderingEngine.WEBKIT, null); // not detectable any longer. 
-	
+	APPLE_MAIL(		Manufacturer.APPLE, null, 51, "Apple Mail", new String[0], null, BrowserType.EMAIL_CLIENT, RenderingEngine.WEBKIT, null); // not detectable any longer.
+
 	/*
-	 * An id for each browser version which is unique per manufacturer. 
+	 * An id for each browser version which is unique per manufacturer.
 	 */
 	private final short id;
 	private final String name;
@@ -252,10 +254,11 @@ public enum Browser {
 	private final Manufacturer manufacturer;
 	private final RenderingEngine renderingEngine;
 	private final Browser parent;
+        private final String versionRegExString;
 	private List<Browser> children;
 	private Pattern versionRegEx;
 	private static List<Browser> topLevelBrowsers;
-	
+
 	private Browser(Manufacturer manufacturer, Browser parent, int versionId, String name, String[] aliases, String[] exclude, BrowserType browserType, RenderingEngine renderingEngine, String versionRegexString) {
 		this.id =  (short) ( ( manufacturer.getId() << 8) + (byte) versionId);
 		this.name = name;
@@ -266,13 +269,61 @@ public enum Browser {
 		this.browserType = browserType;
 		this.manufacturer = manufacturer;
 		this.renderingEngine = renderingEngine;
-		if (versionRegexString != null)
-			this.versionRegEx = Pattern.compile(versionRegexString);
-		if (this.parent == null) 
+		if (versionRegexString != null) {
+                    this.versionRegExString = versionRegexString;
+                    this.versionRegEx = Pattern.compile(versionRegexString);
+                } else {
+                    this.versionRegExString = null;
+                }
+		if (this.parent == null)
 			addTopLevelBrowser(this);
-		else 
+		else
 			this.parent.children.add(this);
 	}
+
+        public JSONObject toJSON() {
+            JSONObject o        = new JSONObject();
+            JSONArray c         = new JSONArray();
+            Browser group       = this.getGroup();
+
+            o.element("family", group.toString().toLowerCase());
+            o.element("name", this.name.toLowerCase());
+            o.element("manufacturer", this.manufacturer.toString().toLowerCase());
+            o.element("browser_type", this.browserType.toString().toLowerCase());
+            o.element("rendering_engine", this.renderingEngine.toString().toLowerCase());
+            if (this.versionRegExString != null) {
+                o.element("version_regex", this.versionRegExString.toLowerCase());
+            }
+
+            if (this.aliases != null) {
+                JSONArray aliases = new JSONArray();
+                for (String alias : this.aliases) {
+                    aliases.element(alias.toLowerCase());
+                }
+                o.element("aliases", aliases);
+            }
+
+            if (this.excludeList != null) {
+                JSONArray exclusions = new JSONArray();
+                for (String exclusion : this.excludeList) {
+                    exclusions.element(exclusion.toLowerCase());
+                }
+                o.element("exclusions", exclusions);
+            }
+
+            if (this.children != null) {
+                for (Browser child : this.children) {
+                    c.element(child.toJSON());
+                }
+                o.element("children", c);
+            }
+
+            return o;
+        }
+
+        public static List<Browser> getBrowsers() {
+            return topLevelBrowsers;
+        }
 
   private static String[] toLowerCase(String[] strArr) {
     if (strArr == null) return null;
@@ -287,10 +338,10 @@ public enum Browser {
 	// create collection of top level browsers during initialization
 	private static void addTopLevelBrowser(Browser browser) {
 		if(topLevelBrowsers == null)
-			topLevelBrowsers = new ArrayList<Browser>();	
+			topLevelBrowsers = new ArrayList<Browser>();
 		topLevelBrowsers.add(browser);
 	}
-	
+
 	public short getId() {
 		return id;
 	}
@@ -298,7 +349,7 @@ public enum Browser {
 	public String getName() {
 		return name;
 	}
-	
+
 	private Pattern getVersionRegEx() {
 		if (this.versionRegEx == null) {
 			if (this.getGroup() != this)
@@ -308,9 +359,9 @@ public enum Browser {
 		}
 		return this.versionRegEx;
 	}
-	
+
 	/**
-	 * Detects the detailed version information of the browser. Depends on the userAgent to be available. 
+	 * Detects the detailed version information of the browser. Depends on the userAgent to be available.
 	 * Returns null if it can not detect the version information.
 	 * @return Version
 	 */
@@ -329,7 +380,7 @@ public enum Browser {
 		}
 		return null;
 	}
-	
+
 	/**
 	 * @return the browserType
 	 */
@@ -343,7 +394,7 @@ public enum Browser {
 	public Manufacturer getManufacturer() {
 		return manufacturer;
 	}
-	
+
 	/**
 	 * @return the rendering engine
 	 */
@@ -362,8 +413,8 @@ public enum Browser {
 	}
 
 	/*
-	 * Checks if the given user-agent string matches to the browser. 
-	 * Only checks for one specific browser. 
+	 * Checks if the given user-agent string matches to the browser.
+	 * Only checks for one specific browser.
 	 */
 	public boolean isInUserAgentString(String agentString)
 	{
@@ -377,7 +428,7 @@ public enum Browser {
 		}
 		return false;
 	}
-	
+
 	/**
 	 * Checks if the given user-agent does not contain one of the tokens which should not match.
 	 * In most cases there are no excluding tokens, so the impact should be small.
@@ -397,33 +448,33 @@ public enum Browser {
 		}
 		return false;
 	}
-	
+
 	private Browser checkUserAgent(String agentString) {
 		if (this.isInUserAgentString(agentString)) {
-			
+
 			if (this.children.size() > 0) {
 				for (Browser childBrowser : this.children) {
 					Browser match = childBrowser.checkUserAgent(agentString);
-					if (match != null) { 
+					if (match != null) {
 						return match;
 					}
 				}
 			}
-			
+
 			// if children didn't match we continue checking the current to prevent false positives
 			if (!this.containsExcludeToken(agentString)) {
 				return this;
 			}
-			
+
 		}
 		return null;
 	}
-	
+
 	/**
-	 * Iterates over all Browsers to compare the browser signature with 
+	 * Iterates over all Browsers to compare the browser signature with
 	 * the user agent string. If no match can be found Browser.UNKNOWN will
 	 * be returned.
-	 * Starts with the top level browsers and only if one of those matches 
+	 * Starts with the top level browsers and only if one of those matches
 	 * checks children browsers.
 	 * Steps out of loop as soon as there is a match.
 	 * @param agentString
@@ -433,10 +484,10 @@ public enum Browser {
 	{
 		return parseUserAgentString(agentString, topLevelBrowsers);
 	}
-	
+
 	/**
-	 * Iterates over the given Browsers (incl. children) to compare the browser 
-	 * signature with the user agent string. 
+	 * Iterates over the given Browsers (incl. children) to compare the browser
+	 * signature with the user agent string.
 	 * If no match can be found Browser.UNKNOWN will be returned.
 	 * Steps out of loop as soon as there is a match.
 	 * Be aware that if the order of the provided Browsers is incorrect or if the set is too limited it can lead to false matches!
@@ -453,12 +504,12 @@ public enum Browser {
 		}
 		return Browser.UNKNOWN;
 	}
-		
+
 	/**
 	 * Returns the enum constant of this type with the specified id.
 	 * Throws IllegalArgumentException if the value does not exist.
 	 * @param id
-	 * @return 
+	 * @return
 	 */
 	public static Browser valueOf(short id)
 	{
@@ -467,12 +518,12 @@ public enum Browser {
 			if (browser.getId() == id)
 				return browser;
 		}
-		
+
 		// same behavior as standard valueOf(string) method
 		throw new IllegalArgumentException(
 	            "No enum const for id " + id);
 	}
-	
-	
-	
+
+
+
 }

--- a/src/main/java/eu/bitwalker/useragentutils/OperatingSystem.java
+++ b/src/main/java/eu/bitwalker/useragentutils/OperatingSystem.java
@@ -1,25 +1,25 @@
 /*
 * Copyright (c) 2008-2014, Harald Walker (bitwalker.eu) and contributing developers
 * All rights reserved.
-* 
+*
 * Redistribution and use in source and binary forms, with or
 * without modification, are permitted provided that the
 * following conditions are met:
-* 
+*
 * * Redistributions of source code must retain the above
 * copyright notice, this list of conditions and the following
 * disclaimer.
-* 
+*
 * * Redistributions in binary form must reproduce the above
 * copyright notice, this list of conditions and the following
 * disclaimer in the documentation and/or other materials
 * provided with the distribution.
-* 
+*
 * * Neither the name of bitwalker nor the names of its
 * contributors may be used to endorse or promote products
 * derived from this software without specific prior written
 * permission.
-* 
+*
 * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
 * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
 * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
@@ -40,6 +40,7 @@ package eu.bitwalker.useragentutils;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
+import net.sf.json.*;
 
 /**
  * Enum constants for most common operating systems.
@@ -51,7 +52,7 @@ public enum OperatingSystem {
 	/**
 	 * Windows Mobile / Windows CE. Exact version unknown.
 	 */
-	WINDOWS(		Manufacturer.MICROSOFT,null,1, "Windows", new String[] { "Windows" }, new String[] { "Palm", "ggpht.com"  }, DeviceType.COMPUTER, null ), // catch the rest of older Windows systems (95, NT,...)
+	WINDOWS(		Manufacturer.MICROSOFT,null,1, "Windows", new String[] { "Windows" }, new String[] { "Palm", "ggpht.com"  }, DeviceType.COMPUTER, "Windows (?:NT|(?:Phone(?: OS)?))? (([0-9]+)(?:\\.([0-9]+)))" ), // catch the rest of older Windows systems (95, NT,...)
 		WINDOWS_81(		Manufacturer.MICROSOFT,OperatingSystem.WINDOWS,23, "Windows 8.1", new String[] { "Windows NT 6.3" }, null, DeviceType.COMPUTER, null ), // before Win, yes, Windows 8.1 is called 6.3 LOL
 		WINDOWS_8(		Manufacturer.MICROSOFT,OperatingSystem.WINDOWS,22, "Windows 8", new String[] { "Windows NT 6.2" }, null, DeviceType.COMPUTER, null ), // before Win, yes, Windows 8 is called 6.2 LOL
 		WINDOWS_7(		Manufacturer.MICROSOFT,OperatingSystem.WINDOWS,21, "Windows 7", new String[] { "Windows NT 6.1" }, null, DeviceType.COMPUTER, null ), // before Win, yes, Windows 7 is called 6.1 LOL
@@ -62,9 +63,9 @@ public enum OperatingSystem {
 		WINDOWS_PHONE8(Manufacturer.MICROSOFT,OperatingSystem.WINDOWS, 52, "Windows Phone 8", new String[] { "Windows Phone 8" },  null, DeviceType.MOBILE, null ), // before Win
 		WINDOWS_MOBILE7(Manufacturer.MICROSOFT,OperatingSystem.WINDOWS, 51, "Windows Phone 7", new String[] { "Windows Phone OS 7" },  null, DeviceType.MOBILE, null ), // should be Windows Phone 7 but to keep it compatible we'll leave the name as is.
 		WINDOWS_MOBILE(	Manufacturer.MICROSOFT,OperatingSystem.WINDOWS, 50, "Windows Mobile", new String[] { "Windows CE" },  null, DeviceType.MOBILE, null ), // before Win
-		WINDOWS_98(		Manufacturer.MICROSOFT,OperatingSystem.WINDOWS,5, "Windows 98", new String[] { "Windows 98","Win98" },  new String[] { "Palm" }, DeviceType.COMPUTER, null ), // before Win 
+		WINDOWS_98(		Manufacturer.MICROSOFT,OperatingSystem.WINDOWS,5, "Windows 98", new String[] { "Windows 98","Win98" },  new String[] { "Palm" }, DeviceType.COMPUTER, null ), // before Win
 
-	ANDROID(		Manufacturer.GOOGLE,null, 0, "Android", new String[] { "Android" },  null, DeviceType.MOBILE, null ),
+	ANDROID(		Manufacturer.GOOGLE,null, 0, "Android", new String[] { "Android" },  null, DeviceType.MOBILE, "Android (([0-9]+)\\.([0-9]+)(?:\\.([0-9]+))?)"),
 		ANDROID4(		Manufacturer.GOOGLE,OperatingSystem.ANDROID, 4, "Android 4.x", new String[] { "Android 4","Android-4" },  null, DeviceType.MOBILE, null ),
 		ANDROID4_TABLET(Manufacturer.GOOGLE,OperatingSystem.ANDROID4, 40, "Android 4.x Tablet", new String[] { "Android 4","Android-4" },   new String[] { "mobile" }, DeviceType.TABLET, null ),
 		ANDROID3_TABLET(Manufacturer.GOOGLE,OperatingSystem.ANDROID, 30, "Android 3.x Tablet", new String[] { "Android 3" },  null, DeviceType.TABLET, null ), // as long as there are not Android 3.x phones this should be enough
@@ -80,18 +81,18 @@ public enum OperatingSystem {
 		 */
 		ANDROID_TABLET(	Manufacturer.GOOGLE,OperatingSystem.ANDROID, 12, "Android Tablet", new String[] { "Tablet" },  null, DeviceType.TABLET, null ),
 
-	
+
 	/**
 	 * PalmOS, exact version unkown
 	 */
-	WEBOS(			Manufacturer.HP,null,11, "WebOS", new String[] { "webOS" },  null, DeviceType.MOBILE, null ), 
-	PALM(			Manufacturer.HP,null,10, "PalmOS", new String[] { "Palm" },  null, DeviceType.MOBILE, null ), 
-	MEEGO(			Manufacturer.NOKIA,null,3, "MeeGo", new String[] { "MeeGo" },  null, DeviceType.MOBILE, null ),		
+	WEBOS(			Manufacturer.HP,null,11, "WebOS", new String[] { "webOS" },  null, DeviceType.MOBILE, "webOS\\/(([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(?:\\.([0-9]+))?)" ),
+	PALM(			Manufacturer.HP,null,10, "PalmOS", new String[] { "Palm" },  null, DeviceType.MOBILE, null ),
+	MEEGO(			Manufacturer.NOKIA,null,3, "MeeGo", new String[] { "MeeGo" },  null, DeviceType.MOBILE, null ),
 
 	/**
 	 * iOS4, with the release of the iPhone 4, Apple renamed the OS to iOS.
-	 */	
-	IOS(			Manufacturer.APPLE,null, 2, "iOS", new String[] { "iPhone OS", "like Mac OS X" },  null, DeviceType.MOBILE, null ), // before MAC_OS_X_IPHONE for all older versions
+	 */
+	IOS(			Manufacturer.APPLE,null, 2, "iOS", new String[] { "iPhone OS", "like Mac OS X" },  null, DeviceType.MOBILE, "CPU(?: iPhone)? OS (([0-9]+)(?:_([0-9]+))?(?:_([0-9]+))?)" ), // before MAC_OS_X_IPHONE for all older versions
 		iOS7_IPHONE(	Manufacturer.APPLE,OperatingSystem.IOS, 44, "iOS 7 (iPhone)", new String[] { "iPhone OS 7" },  null, DeviceType.MOBILE, null ), // before MAC_OS_X_IPHONE for all older versions
 		iOS6_IPHONE(	Manufacturer.APPLE,OperatingSystem.IOS, 43, "iOS 6 (iPhone)", new String[] { "iPhone OS 6" },  null, DeviceType.MOBILE, null ), // before MAC_OS_X_IPHONE for all older versions
 		iOS5_IPHONE(	Manufacturer.APPLE,OperatingSystem.IOS, 42, "iOS 5 (iPhone)", new String[] { "iPhone OS 5" },  null, DeviceType.MOBILE, null ), // before MAC_OS_X_IPHONE for all older versions
@@ -101,8 +102,8 @@ public enum OperatingSystem {
 		iOS6_IPAD(	Manufacturer.APPLE, OperatingSystem.MAC_OS_X_IPAD, 51, "iOS 6 (iPad)", new String[] { "OS 6" },  null, DeviceType.TABLET, null ), // before Mac OS X
 		MAC_OS_X_IPHONE(Manufacturer.APPLE, OperatingSystem.IOS, 40, "Mac OS X (iPhone)", new String[] { "iPhone" },  null, DeviceType.MOBILE, null ), // before Mac OS X
 		MAC_OS_X_IPOD(	Manufacturer.APPLE, OperatingSystem.IOS, 30, "Mac OS X (iPod)", new String[] { "iPod" },  null, DeviceType.MOBILE, null ), // before Mac OS X
-	
-	MAC_OS_X(		Manufacturer.APPLE,null, 10, "Mac OS X", new String[] { "Mac OS X" , "CFNetwork"}, null, DeviceType.COMPUTER, null ), // before Mac	
+
+	MAC_OS_X(		Manufacturer.APPLE,null, 10, "Mac OS X", new String[] { "Mac OS X" , "CFNetwork"}, null, DeviceType.COMPUTER, "Mac OS ?X (([0-9]+)(?:[_\\.]([0-9]+))?(?:[_\\.]([0-9]+)))" ), // before Mac
 
 	/**
 	 * Older Mac OS systems before Mac OS X
@@ -122,20 +123,20 @@ public enum OperatingSystem {
     /**
      *  Google TV uses Android 2.x or 3.x but doesn't identify itself as Android.
      */
-	GOOGLE_TV(		Manufacturer.GOOGLE,null, 100, "Android (Google TV)", new String[] { "GoogleTV" }, null, DeviceType.DMR, null ),	
+	GOOGLE_TV(		Manufacturer.GOOGLE,null, 100, "Android (Google TV)", new String[] { "GoogleTV" }, null, DeviceType.DMR, null ),
 
 	/**
 	 * Various Linux based operating systems.
 	 */
-	KINDLE(			Manufacturer.AMAZON,null, 1, "Linux (Kindle)", new String[] { "Kindle" }, null, DeviceType.TABLET, null ),	
-		KINDLE3(		Manufacturer.AMAZON,OperatingSystem.KINDLE, 30, "Linux (Kindle 3)", new String[] { "Kindle/3" }, null, DeviceType.TABLET, null ),	
-		KINDLE2(		Manufacturer.AMAZON,OperatingSystem.KINDLE, 20, "Linux (Kindle 2)", new String[] { "Kindle/2" }, null, DeviceType.TABLET, null ),	
+	KINDLE(			Manufacturer.AMAZON,null, 1, "Linux (Kindle)", new String[] { "Kindle" }, null, DeviceType.TABLET, null ),
+		KINDLE3(		Manufacturer.AMAZON,OperatingSystem.KINDLE, 30, "Linux (Kindle 3)", new String[] { "Kindle/3" }, null, DeviceType.TABLET, null ),
+		KINDLE2(		Manufacturer.AMAZON,OperatingSystem.KINDLE, 20, "Linux (Kindle 2)", new String[] { "Kindle/2" }, null, DeviceType.TABLET, null ),
 	LINUX(			Manufacturer.OTHER,null, 2, "Linux", new String[] { "Linux" , "CamelHttpStream" }, null, DeviceType.COMPUTER, null ), // CamelHttpStream is being used by Evolution, an email client for Linux
 
 	/**
 	 * Other Symbian OS versions
 	 */
-	SYMBIAN(		Manufacturer.SYMBIAN,null, 1, "Symbian OS", new String[] { "Symbian", "Series60"},  null, DeviceType.MOBILE, null ),	
+	SYMBIAN(		Manufacturer.SYMBIAN,null, 1, "Symbian OS", new String[] { "Symbian", "Series60"},  null, DeviceType.MOBILE, null ),
 		/**
 		 * Symbian OS 9.x versions. Being used by Nokia (N71, N73, N81, N82, N91, N92, N95, ...)
 		 */
@@ -145,8 +146,8 @@ public enum OperatingSystem {
 		 */
 		SYMBIAN8(		Manufacturer.SYMBIAN,OperatingSystem.SYMBIAN, 15, "Symbian OS 8.x", new String[] { "SymbianOS/8", "Series60/2.6", "Series60/2.8"},  null, DeviceType.MOBILE, null ),
 		/**
-		 * Symbian OS 7.x versions. Being used by Nokia (3230, 6260, 6600, 6620, 6670, 7610), 
-		 * Panasonic (X700, X800), Samsung (SGH-D720, SGH-D730) and Lenovo (P930). 
+		 * Symbian OS 7.x versions. Being used by Nokia (3230, 6260, 6600, 6620, 6670, 7610),
+		 * Panasonic (X700, X800), Samsung (SGH-D720, SGH-D730) and Lenovo (P930).
 		 */
 		SYMBIAN7(		Manufacturer.SYMBIAN,OperatingSystem.SYMBIAN, 10, "Symbian OS 7.x", new String[] { "SymbianOS/7"},  null, DeviceType.MOBILE, null ),
 		/**
@@ -158,26 +159,26 @@ public enum OperatingSystem {
 	 */
 	SERIES40 ( 		Manufacturer.NOKIA,null, 1, "Series 40", new String[] { "Nokia6300"},  null, DeviceType.MOBILE, null ),
 	/**
-	 * Proprietary operating system used for many Sony Ericsson phones. 
+	 * Proprietary operating system used for many Sony Ericsson phones.
 	 */
 	SONY_ERICSSON ( Manufacturer.SONY_ERICSSON, null, 1, "Sony Ericsson", new String[] { "SonyEricsson"},  null, DeviceType.MOBILE, null  ), // after symbian, some SE phones use symbian
 	SUN_OS(			Manufacturer.SUN, null, 1, "SunOS", new String[] { "SunOS" } ,  null, DeviceType.COMPUTER, null ),
-	PSP(			Manufacturer.SONY, null, 1, "Sony Playstation", new String[] { "Playstation" }, null, DeviceType.GAME_CONSOLE, null ), 
+	PSP(			Manufacturer.SONY, null, 1, "Sony Playstation", new String[] { "Playstation" }, null, DeviceType.GAME_CONSOLE, null ),
 	/**
 	 * Nintendo Wii game console.
 	 */
-	WII(			Manufacturer.NINTENDO,null, 1, "Nintendo Wii", new String[] { "Wii" }, null, DeviceType.GAME_CONSOLE, null ), 
+	WII(			Manufacturer.NINTENDO,null, 1, "Nintendo Wii", new String[] { "Wii" }, null, DeviceType.GAME_CONSOLE, null ),
 	/**
 	 * BlackBerryOS. The BlackBerryOS exists in different version. How relevant those versions are, is not clear.
 	 */
-	BLACKBERRY(		Manufacturer.BLACKBERRY,null, 1, "BlackBerryOS", new String[] { "BlackBerry" }, null, DeviceType.MOBILE, null ),	
-		BLACKBERRY7(	Manufacturer.BLACKBERRY,OperatingSystem.BLACKBERRY, 7, "BlackBerry 7", new String[] { "Version/7" }, null, DeviceType.MOBILE, null ),	
-		BLACKBERRY6(	Manufacturer.BLACKBERRY,OperatingSystem.BLACKBERRY, 6, "BlackBerry 6", new String[] { "Version/6" }, null, DeviceType.MOBILE, null ),		
+	BLACKBERRY(		Manufacturer.BLACKBERRY,null, 1, "BlackBerryOS", new String[] { "BlackBerry" }, null, DeviceType.MOBILE, null ),
+		BLACKBERRY7(	Manufacturer.BLACKBERRY,OperatingSystem.BLACKBERRY, 7, "BlackBerry 7", new String[] { "Version/7" }, null, DeviceType.MOBILE, null ),
+		BLACKBERRY6(	Manufacturer.BLACKBERRY,OperatingSystem.BLACKBERRY, 6, "BlackBerry 6", new String[] { "Version/6" }, null, DeviceType.MOBILE, null ),
 
-	BLACKBERRY_TABLET(Manufacturer.BLACKBERRY,null, 100, "BlackBerry Tablet OS", new String[] { "RIM Tablet OS" }, null, DeviceType.TABLET, null ),	
-	
+	BLACKBERRY_TABLET(Manufacturer.BLACKBERRY,null, 100, "BlackBerry Tablet OS", new String[] { "RIM Tablet OS" }, null, DeviceType.TABLET, null ),
+
 	ROKU(			Manufacturer.ROKU,null, 1, "Roku OS", new String[] { "Roku" }, null, DeviceType.DMR, null ),
-	
+
 	/**
 	 * Proxy server that hides the original user-agent.
 	 * ggpht.com = Gmail proxy server
@@ -187,7 +188,7 @@ public enum OperatingSystem {
 	UNKNOWN_MOBILE(	Manufacturer.OTHER,null, 3, "Unknown mobile", new String[] {"Mobile"}, null, DeviceType.MOBILE, null ),
 	UNKNOWN_TABLET(	Manufacturer.OTHER,null, 4, "Unknown tablet", new String[] {"Tablet"}, null, DeviceType.TABLET, null ),
 	UNKNOWN(		Manufacturer.OTHER,null, 1, "Unknown", new String[0], null, DeviceType.UNKNOWN, null );
-	
+
 	private final short id;
 	private final String name;
 	private final String[] aliases;
@@ -196,21 +197,23 @@ public enum OperatingSystem {
 	private final DeviceType deviceType;
 	private final OperatingSystem parent;
 	private List<OperatingSystem> children;
+        private String versionRegExString;
 	private Pattern versionRegEx;
 	private static List<OperatingSystem> topLevelOperatingSystems;
-	
+
 	private OperatingSystem(Manufacturer manufacturer, OperatingSystem parent, int versionId, String name, String[] aliases,
 		 String[] exclude, DeviceType deviceType, String versionRegexString) {
 		this.manufacturer = manufacturer;
 		this.parent = parent;
 		this.children = new ArrayList<OperatingSystem>();
-		// combine manufacturer and version id to one unique id. 
+		// combine manufacturer and version id to one unique id.
 		this.id =  (short) ( ( manufacturer.getId() << 8) + (byte) versionId);
 		this.name = name;
 		this.aliases = aliases;
 		this.excludeList = exclude;
 		this.deviceType = deviceType;
 		if (versionRegexString != null) { // not implemented yet
+                    this.versionRegExString = versionRegexString;
 			this.versionRegEx = Pattern.compile(versionRegexString);
 		}
 		if (this.parent == null)
@@ -219,13 +222,57 @@ public enum OperatingSystem {
 			this.parent.children.add(this);
 	}
 
+        public JSONObject toJSON() {
+            JSONObject o        = new JSONObject();
+            JSONArray c         = new JSONArray();
+            OperatingSystem os  = this.getGroup();
+
+            o.element("family", os.toString().toLowerCase());
+            o.element("name", this.name.toLowerCase());
+            o.element("manufacturer", this.manufacturer.toString().toLowerCase());
+            o.element("device_type", this.deviceType.toString().toLowerCase());
+
+            if (this.versionRegExString != null) {
+                o.element("version_regex", this.versionRegExString.toLowerCase());
+            }
+
+            if (this.aliases != null) {
+                JSONArray aliases = new JSONArray();
+                for (String alias : this.aliases) {
+                    aliases.element(alias.toLowerCase());
+                }
+                o.element("aliases", aliases);
+            }
+
+            if (this.excludeList != null) {
+                JSONArray exclusions = new JSONArray();
+                for (String exclude : this.excludeList) {
+                    exclusions.element(exclude.toLowerCase());
+                }
+                o.element("exclusions", exclusions);
+            }
+
+            if (this.children != null) {
+                for (OperatingSystem child : this.children) {
+                    c.element(child.toJSON());
+                }
+                o.element("children", c);
+            }
+
+            return o;
+        }
+
+        public static List<OperatingSystem> getOperatingSystems() {
+            return topLevelOperatingSystems;
+        }
+
 	// create collection of top level operating systems during initialization
 	private static void addTopLevelOperatingSystem(OperatingSystem os) {
 		if(topLevelOperatingSystems == null)
-			topLevelOperatingSystems = new ArrayList<OperatingSystem>();	
+			topLevelOperatingSystems = new ArrayList<OperatingSystem>();
 		topLevelOperatingSystems.add(os);
 	}
-	
+
 	public short getId() {
 		return id;
 	}
@@ -234,7 +281,7 @@ public enum OperatingSystem {
 		return name;
 	}
 
-	
+
 	/*
 	 * Shortcut to check of an operating system is a mobile device.
 	 * Left in here for backwards compatibility.
@@ -242,11 +289,11 @@ public enum OperatingSystem {
 	public boolean isMobileDevice() {
 		return deviceType.equals(DeviceType.MOBILE);
 	}
-		
+
 	public DeviceType getDeviceType() {
 		return deviceType;
 	}
-	
+
 	/*
 	 * Gets the top level grouping operating system
 	 */
@@ -266,21 +313,21 @@ public enum OperatingSystem {
 	}
 
 	/**
-	 * Checks if the given user-agent string matches to the operating system. 
-	 * Only checks for one specific operating system. 
+	 * Checks if the given user-agent string matches to the operating system.
+	 * Only checks for one specific operating system.
 	 * @param agentString
 	 * @return boolean
 	 */
 	public boolean isInUserAgentString(String agentString)
-	{		
+	{
 		for (String alias : aliases)
 		{
 			if (agentString != null && agentString.toLowerCase().indexOf(alias.toLowerCase()) != -1)
 				return true;
-		}	
+		}
 		return false;
 	}
-	
+
 	/**
 	 * Checks if the given user-agent does not contain one of the tokens which should not match.
 	 * In most cases there are no excluding tokens, so the impact should be small.
@@ -297,13 +344,13 @@ public enum OperatingSystem {
 		}
 		return false;
 	}
-		
+
 	private OperatingSystem checkUserAgent(String agentString) {
 		if (this.isInUserAgentString(agentString)) {
 			if (this.children.size() > 0) {
 				for (OperatingSystem childOperatingSystem : this.children) {
 					OperatingSystem match = childOperatingSystem.checkUserAgent(agentString);
-					if (match != null) { 
+					if (match != null) {
 						return match;
 					}
 				}
@@ -312,13 +359,13 @@ public enum OperatingSystem {
 			if (!this.containsExcludeToken(agentString)) {
 				return this;
 			}
-			
+
 		}
 		return null;
 	}
-	
+
 	/**
-	 * Parses user agent string and returns the best match. 
+	 * Parses user agent string and returns the best match.
 	 * Returns OperatingSystem.UNKNOWN if there is no match.
 	 * @param agentString
 	 * @return OperatingSystem
@@ -327,9 +374,9 @@ public enum OperatingSystem {
 	{
 		return parseUserAgentString(agentString, topLevelOperatingSystems);
 	}
-	
+
 	/**
-	 * Parses the user agent string and returns the best match for the given operating systems. 
+	 * Parses the user agent string and returns the best match for the given operating systems.
 	 * Returns OperatingSystem.UNKNOWN if there is no match.
 	 * Be aware that if the order of the provided operating systems is incorrect or the set is too limited it can lead to false matches!
 	 * @param agentString
@@ -343,15 +390,15 @@ public enum OperatingSystem {
 			if (match != null) {
 				return match; // either current operatingSystem or a child object
 			}
-		}	
+		}
 		return OperatingSystem.UNKNOWN;
 	}
-		
+
 	/**
 	 * Returns the enum constant of this type with the specified id.
 	 * Throws IllegalArgumentException if the value does not exist.
 	 * @param id
-	 * @return 
+	 * @return
 	 */
 	public static OperatingSystem valueOf(short id)
 	{
@@ -360,10 +407,10 @@ public enum OperatingSystem {
 			if (operatingSystem.getId() == id)
 				return operatingSystem;
 		}
-		
+
 		// same behavior as standard valueOf(string) method
 		throw new IllegalArgumentException(
 	            "No enum const for id " + id);
 	}
-	
+
 }

--- a/src/main/java/eu/bitwalker/useragentutils/RenderingEngine.java
+++ b/src/main/java/eu/bitwalker/useragentutils/RenderingEngine.java
@@ -1,25 +1,25 @@
 /*
-* Copyright (c) 2008-2014, Harald Walker (bitwalker.eu) and contributing developers 
+* Copyright (c) 2008-2014, Harald Walker (bitwalker.eu) and contributing developers
 * All rights reserved.
-* 
+*
 * Redistribution and use in source and binary forms, with or
 * without modification, are permitted provided that the
 * following conditions are met:
-* 
+*
 * * Redistributions of source code must retain the above
 * copyright notice, this list of conditions and the following
 * disclaimer.
-* 
+*
 * * Redistributions in binary form must reproduce the above
 * copyright notice, this list of conditions and the following
 * disclaimer in the documentation and/or other materials
 * provided with the distribution.
-* 
+*
 * * Neither the name of bitwalker nor the names of its
 * contributors may be used to endorse or promote products
 * derived from this software without specific prior written
 * permission.
-* 
+*
 * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
 * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
 * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
@@ -42,13 +42,13 @@ package eu.bitwalker.useragentutils;
  *
  */
 public enum RenderingEngine {
-	
+
 	/**
 	 * Trident is the the Microsoft layout engine, mainly used by Internet Explorer.
 	 */
 	TRIDENT("Trident"),
 	/**
-	 * HTML parsing and rendering engine of Microsoft Office Word, used by some other products of the Office suite instead of Trident. 
+	 * HTML parsing and rendering engine of Microsoft Office Word, used by some other products of the Office suite instead of Trident.
 	 */
 	WORD("Microsoft Office Word"),
 	/**
@@ -75,11 +75,15 @@ public enum RenderingEngine {
 	 * Other or unknown layout engine.
 	 */
 	OTHER("Other");
-	
+
 	String name;
-	
+
 	private RenderingEngine(String name) {
 		this.name = name;
 	}
+
+        public String getName() {
+            return this.name;
+        }
 
 }

--- a/src/main/java/fauxsoup/Extract.java
+++ b/src/main/java/fauxsoup/Extract.java
@@ -1,0 +1,35 @@
+package fauxsoup;
+
+import java.util.ArrayList;
+import java.util.List;
+import eu.bitwalker.useragentutils.*;
+import net.sf.json.JSONSerializer;
+import net.sf.json.JSONObject;
+import net.sf.json.JSONArray;
+import java.io.*;
+
+public class Extract {
+    public static void main(String[] args) throws IOException {
+        JSONArray browsers = new JSONArray();
+        for (Browser b : Browser.getBrowsers()) {
+            browsers.element(b.toJSON());
+        }
+
+        JSONArray operating_systems = new JSONArray();
+        for (OperatingSystem os : OperatingSystem.getOperatingSystems()) {
+            operating_systems.element(os.toJSON());
+        }
+
+        write_file("browsers.json", browsers.toString(4));
+        write_file("operating_systems.json", operating_systems.toString(4));
+    }
+
+    private static void write_file(String file, String contents) throws IOException {
+        FileWriter fw = new FileWriter(file, false);
+        PrintWriter pw = new PrintWriter(fw);
+
+        pw.print(contents);
+
+        pw.close();
+    }
+}


### PR DESCRIPTION
These modifications allow dumping of the hierarchical Browser and OperatingSystem lists to JSON, allowing for implementations in other languages. Only important details are dumped, and I generally used the friendlier enumeration name for things like manufacturer, rendering engine, and family names.

A few modifications were made to the objects to allow for easier dumping, including adding static functions to retrieve the top-level OS/Browsers, and preserving the string form of the version regex so that it can be included in the dump.

I have done this because your method is *by far* the most efficient method for parsing User Agent strings I have yet encountered, but is woefully unavailable outside of Java because of your use of constants/enumerations (though this also contributes to the efficiency of the operation).

To see it in action, merely execute the main function in fauxsoup.Extract (open to renaming this package),