### PR TITLE
Make all fields in Browser.java final

### DIFF
--- a/src/main/java/eu/bitwalker/useragentutils/Browser.java
+++ b/src/main/java/eu/bitwalker/useragentutils/Browser.java
@@ -38,7 +38,10 @@
 package eu.bitwalker.useragentutils;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.EnumSet;
 import java.util.List;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -280,22 +283,28 @@ public enum Browser {
 	private final Manufacturer manufacturer;
 	private final RenderingEngine renderingEngine;
 	private final Browser parent;
-	private List<Browser> children;
-	private Pattern versionRegEx;
-	private static List<Browser> topLevelBrowsers;
+	private final List<Browser> children = new ArrayList<Browser>();
+	private final Pattern versionRegEx;
+	private static final Set<Browser> topLevelBrowsers = EnumSet.copyOf(Holder.topLevelBrowsers);
+	private static final class Holder {
+		static final List<Browser> topLevelBrowsers = new ArrayList<Browser>();
+	}
 	
 	private Browser(Manufacturer manufacturer, Browser parent, int versionId, String name, String[] aliases, String[] exclude, BrowserType browserType, RenderingEngine renderingEngine, String versionRegexString) {
 		this.id =  (short) ( ( manufacturer.getId() << 8) + (byte) versionId);
 		this.name = name;
 		this.parent = parent;
-		this.children = new ArrayList<Browser>();
 		this.aliases = toLowerCase(aliases);
 		this.excludeList = toLowerCase(exclude);
 		this.browserType = browserType;
 		this.manufacturer = manufacturer;
 		this.renderingEngine = renderingEngine;
+    
 		if (versionRegexString != null)
 			this.versionRegEx = Pattern.compile(versionRegexString);
+		else
+			this.versionRegEx = null;
+      
 		if (this.parent == null) 
 			addTopLevelBrowser(this);
 		else 
@@ -311,12 +320,9 @@ public enum Browser {
     return res;
   }
 
-
 	// create collection of top level browsers during initialization
 	private static void addTopLevelBrowser(Browser browser) {
-		if(topLevelBrowsers == null)
-			topLevelBrowsers = new ArrayList<Browser>();	
-		topLevelBrowsers.add(browser);
+		Holder.topLevelBrowsers.add(browser);
 	}
 	
 	public short getId() {
@@ -471,7 +477,7 @@ public enum Browser {
 	 * @param agentString
 	 * @return Browser
 	 */
-	public static Browser parseUserAgentString(String agentString, List<Browser> browsers)
+	public static Browser parseUserAgentString(String agentString, Iterable<Browser> browsers)
 	{
 		for (Browser browser : browsers) {
 			Browser match = browser.checkUserAgent(agentString);

--- a/src/main/java/eu/bitwalker/useragentutils/Browser.java
+++ b/src/main/java/eu/bitwalker/useragentutils/Browser.java
@@ -38,10 +38,8 @@
 package eu.bitwalker.useragentutils;
 
 import java.util.ArrayList;
-import java.util.Collection;
-import java.util.EnumSet;
+import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -285,7 +283,9 @@ public enum Browser {
 	private final Browser parent;
 	private final List<Browser> children = new ArrayList<Browser>();
 	private final Pattern versionRegEx;
-	private static final Set<Browser> topLevelBrowsers = EnumSet.copyOf(Holder.topLevelBrowsers);
+	
+	// we need this construct, because instances of an Enum class are loaded before its static initializers
+	private static final List<Browser> topLevelBrowsers = Collections.unmodifiableList(Holder.topLevelBrowsers);
 	private static final class Holder {
 		static final List<Browser> topLevelBrowsers = new ArrayList<Browser>();
 	}

--- a/src/test/java/eu/bitwalker/useragentutils/BrowserTest.java
+++ b/src/test/java/eu/bitwalker/useragentutils/BrowserTest.java
@@ -648,11 +648,11 @@ public class BrowserTest {
 	public void testCustomUserAgentParsing() {
 		// Test limited to the big browser families. As Camino can not be detected any longer, the second best match is Firefox3 (a child of Firefox).
 		for (String agentString : camino2) {
-			assertEquals(Browser.FIREFOX3, Browser.parseUserAgentString(agentString,Arrays.asList(Browser.IE,Browser.CHROME, Browser.APPLE_WEB_KIT, Browser.FIREFOX)));
+			assertEquals(Browser.FIREFOX3, Browser.parseUserAgentString(agentString,Arrays.asList(Browser.IE, Browser.CHROME, Browser.APPLE_WEB_KIT, Browser.FIREFOX)));
 		}
 		// When there is no match in the given set, return UNKNOWN
 		for (String agentString : opera9) {
-			assertEquals(Browser.UNKNOWN, Browser.parseUserAgentString(agentString,Arrays.asList(Browser.IE,Browser.CHROME, Browser.APPLE_WEB_KIT, Browser.FIREFOX)));
+			assertEquals(Browser.UNKNOWN, Browser.parseUserAgentString(agentString,Arrays.asList(Browser.IE, Browser.CHROME, Browser.APPLE_WEB_KIT, Browser.FIREFOX)));
 		}
 	}
 	
@@ -665,12 +665,12 @@ public class BrowserTest {
 	@Test
 	public void testIncompleteUAString() {
 		try {
-			Browser browser = Browser.parseUserAgentString("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_3; en-us) AppleWebKit/531.21.11 (KHTML, like");	
+			Browser browser = Browser.parseUserAgentString("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_3; en-us) AppleWebKit/531.21.11 (KHTML, like");
 			browser.getVersion("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_3; en-us) AppleWebKit/531.21.11 (KHTML, like");
-			Browser browser2 = Browser.parseUserAgentString("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.5; en-US; rv:1.9.0.8) Gecko/2009032608 Firefox");	
+			Browser browser2 = Browser.parseUserAgentString("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.5; en-US; rv:1.9.0.8) Gecko/2009032608 Firefox");
 			browser2.getVersion("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.5; en-US; rv:1.9.0.8) Gecko/2009032608 Firefox");
 			Browser browser3 = Browser.parseUserAgentString("Mozilla/4.0 (compatible; MSIE 8");	
-			browser3.getVersion("Mozilla/4.0 (compatible; MSIE 8");			
+			browser3.getVersion("Mozilla/4.0 (compatible; MSIE 8");
 		} catch (Exception e) {
 			fail(e.getMessage());
 		}


### PR DESCRIPTION
Three fields (two normal, one static) in Browser.java were not set to final, although they never change after initialization.

Getting the static one to be final was a bit tricky, since the constants of an enum class are loaded before its static initializers are executed. The cleanest way to still make it work is to use a private static inner class (a "Holder") that will be initialized on demand; that is, prior to the outer class.
Online source: http://stackoverflow.com/questions/19484155/enum-static-initialization-order

The other two were pretty straight-forward and should have no impact on functionality at all.

I hope you like these changes.
ps: Nice project. : )