### PR TITLE
gh-140 - Match versions properly

### DIFF
--- a/src/main/java/eu/bitwalker/useragentutils/Browser.java
+++ b/src/main/java/eu/bitwalker/useragentutils/Browser.java
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2008-2014, Harald Walker (bitwalker.eu) and contributing developers 
+* Copyright (c) 2008-2014, Harald Walker (bitwalker.eu) and contributing developers
 * All rights reserved.
 * 
 * Redistribution and use in source and binary forms, with or
@@ -14,12 +14,12 @@
 * copyright notice, this list of conditions and the following
 * disclaimer in the documentation and/or other materials
 * provided with the distribution.
-* 
+*
 * * Neither the name of bitwalker nor the names of its
 * contributors may be used to endorse or promote products
 * derived from this software without specific prior written
 * permission.
-* 
+*
 * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
 * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
 * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
@@ -95,19 +95,20 @@ public enum Browser {
 		IE5(			Manufacturer.MICROSOFT, Browser.IE, 50, "Internet Explorer 5", new String[] { "MSIE 5" }, null, BrowserType.WEB_BROWSER, RenderingEngine.TRIDENT, null ), // before MSIE
 
 	/**
-	 * Family of Microsoft Edge browsers. Pretends to be Chrome and claims to be webkit compatible. 
+	 * Family of Microsoft Edge browsers. Pretends to be Chrome and claims to be webkit compatible.
 	 */
 	EDGE(			Manufacturer.MICROSOFT, null, 300, "Microsoft Edge", new String[] {"Edge"}, null, BrowserType.WEB_BROWSER, RenderingEngine.EDGE_HTML, "(?:Edge\\/(([0-9]+)\\.([0-9]*)))"),
 		EDGE_MOBILE(	Manufacturer.MICROSOFT, Browser.EDGE, 304, "Microsoft Edge Mobile", new String[] {"Mobile Safari"}, null, BrowserType.MOBILE_BROWSER, RenderingEngine.EDGE_HTML, null ),
 			EDGE_MOBILE12(Manufacturer.MICROSOFT, Browser.EDGE_MOBILE, 302, "Microsoft Edge Mobile 12", new String[] {"Mobile Safari", "Edge/12"}, null, BrowserType.MOBILE_BROWSER, RenderingEngine.EDGE_HTML, null ),
 		EDGE13(			Manufacturer.MICROSOFT, Browser.EDGE, 303, "Microsoft Edge 13", new String[] {"Edge/13"}, new String[] {"Mobile"}, BrowserType.WEB_BROWSER, RenderingEngine.EDGE_HTML, null ),
 		EDGE12(			Manufacturer.MICROSOFT, Browser.EDGE, 301, "Microsoft Edge 12", new String[] {"Edge/12"}, new String[] {"Mobile"}, BrowserType.WEB_BROWSER, RenderingEngine.EDGE_HTML, null ),
-	
+
 	/**
 	 * Google Chrome browser
 	 */
 	CHROME( 		Manufacturer.GOOGLE, null, 1, "Chrome", new String[] { "Chrome", "CrMo", "CriOS" }, new String[] { "OPR/", "Web Preview", "Vivaldi" } , BrowserType.WEB_BROWSER, RenderingEngine.WEBKIT, "Chrome\\/(([0-9]+)\\.?([\\w]+)?(\\.[\\w]+)?(\\.[\\w]+)?)" ), // before Mozilla
 		CHROME_MOBILE( 	Manufacturer.GOOGLE, Browser.CHROME, 100, "Chrome Mobile", new String[] { "CrMo","CriOS", "Mobile Safari" }, new String[] {"OPR/"}, BrowserType.MOBILE_BROWSER, RenderingEngine.WEBKIT, "(?:CriOS|CrMo|Chrome)\\/(([0-9]+)\\.?([\\w]+)?(\\.[\\w]+)?(\\.[\\w]+)?)" ),
+		CHROME47( 		Manufacturer.GOOGLE, Browser.CHROME, 52, "Chrome 47", new String[] { "Chrome/47" }, new String[] { "OPR/", "Web Preview", "Vivaldi" }, BrowserType.WEB_BROWSER, RenderingEngine.WEBKIT, null ), // before Mozilla
 		CHROME46( 		Manufacturer.GOOGLE, Browser.CHROME, 51, "Chrome 46", new String[] { "Chrome/46" }, new String[] { "OPR/", "Web Preview", "Vivaldi" }, BrowserType.WEB_BROWSER, RenderingEngine.WEBKIT, null ), // before Mozilla
 		CHROME45( 		Manufacturer.GOOGLE, Browser.CHROME, 50, "Chrome 45", new String[] { "Chrome/45" }, new String[] { "OPR/", "Web Preview", "Vivaldi" }, BrowserType.WEB_BROWSER, RenderingEngine.WEBKIT, null ), // before Mozilla
 		CHROME44( 		Manufacturer.GOOGLE, Browser.CHROME, 49, "Chrome 44", new String[] { "Chrome/44" }, new String[] { "OPR/", "Web Preview", "Vivaldi" }, BrowserType.WEB_BROWSER, RenderingEngine.WEBKIT, null ), // before Mozilla
@@ -215,6 +216,7 @@ public enum Browser {
 		FIREFOX3MOBILE(	Manufacturer.MOZILLA, Browser.FIREFOX, 31, "Firefox 3 Mobile", new String[] { "Firefox/3.5 Maemo" }, null, BrowserType.MOBILE_BROWSER, RenderingEngine.GECKO, null ),  // using Gecko Engine
 		FIREFOX_MOBILE(	Manufacturer.MOZILLA, Browser.FIREFOX, 200, "Firefox Mobile", new String[] { "Mobile" }, null, BrowserType.MOBILE_BROWSER, RenderingEngine.GECKO, null ),  // using Gecko Engine
 			FIREFOX_MOBILE23(Manufacturer.MOZILLA, FIREFOX_MOBILE, 223, "Firefox Mobile 23", new String[] { "Firefox/23" }, null, BrowserType.MOBILE_BROWSER, RenderingEngine.GECKO, null ),  // using Gecko Engine
+		FIREFOX43(		Manufacturer.MOZILLA, Browser.FIREFOX, 220, "Firefox 43", new String[] { "Firefox/43" }, null, BrowserType.WEB_BROWSER, RenderingEngine.GECKO, null ),  // using Gecko Engine
 		FIREFOX42(		Manufacturer.MOZILLA, Browser.FIREFOX, 219, "Firefox 42", new String[] { "Firefox/42" }, null, BrowserType.WEB_BROWSER, RenderingEngine.GECKO, null ),  // using Gecko Engine
 		FIREFOX41(		Manufacturer.MOZILLA, Browser.FIREFOX, 218, "Firefox 41", new String[] { "Firefox/41" }, null, BrowserType.WEB_BROWSER, RenderingEngine.GECKO, null ),  // using Gecko Engine
 		FIREFOX40(		Manufacturer.MOZILLA, Browser.FIREFOX, 217, "Firefox 40", new String[] { "Firefox/40" }, null, BrowserType.WEB_BROWSER, RenderingEngine.GECKO, null ),  // using Gecko Engine
@@ -301,7 +303,7 @@ public enum Browser {
 	APPLE_MAIL(		Manufacturer.APPLE, null, 51, "Apple Mail", new String[0], null, BrowserType.EMAIL_CLIENT, RenderingEngine.WEBKIT, null); // not detectable any longer.
 
 	/*
-	 * An id for each browser version which is unique per manufacturer. 
+	 * An id for each browser version which is unique per manufacturer.
 	 */
 	private final short id;
 	private final String name;

--- a/src/main/java/eu/bitwalker/useragentutils/Utils.java
+++ b/src/main/java/eu/bitwalker/useragentutils/Utils.java
@@ -1,5 +1,7 @@
 package eu.bitwalker.useragentutils;
 
+import java.util.regex.Pattern;
+
 public class Utils {
 
     static String[] toLowerCase(String[] strArr) {
@@ -11,12 +13,42 @@ public class Utils {
         return res;
       }
 
+    /**
+     * Checks if str matches strToBeContained with the rules:
+     * <ul>
+     * 	<li>numbers at the end must fully match ("firefox/4" does not match "foo firefox/43 baz", but "firefox/43" does)
+     * 	<li>numbers after the last dot can be ignored ("bar/2" matches "foo bar/2.3 baz" and "bar/2.3" matches "foo bar/2.3.4 baz")
+     *  <li>zeros at the end after a dot are ignored ("bar/2.3" matches "foo bar/2.30" baz)
+     * </ul>
+     * @param str string to be checked
+     * @param strToBeContained string that should be contained/matched in the given str
+     * @return {@code true} if str matched strToBeContained
+     */
+    static boolean matchesWithVersion(String str, String strToBeContained) {
+        if (str.equals(strToBeContained)) {
+            return true;
+        }
+        return Pattern.matches(".*" + Pattern.quote(strToBeContained) + "(\\.\\d+)?(0+|\\D).*", str);
+    }
+
     static boolean contains(String str, String[] strArr) {
         if (strArr == null)
             return false;
         for (String arrStr : strArr) {
-            if (str.contains(arrStr)) {
-                return true;
+            if (arrStr.isEmpty()) {
+                continue;
+            }
+            if (Character.isDigit(arrStr.charAt(arrStr.length() - 1))) {
+                // If the string to compare ends in a number, the full
+                // number must match to that the (unkown) version "firefox/43"
+                // is not matched against firefox/4"
+                if (matchesWithVersion(str, arrStr)) {
+                    return true;
+                }
+            } else {
+                if (str.contains(arrStr)) {
+                    return true;
+                }
             }
         }
         return false;

--- a/src/test/java/eu/bitwalker/useragentutils/UtilsTest.java
+++ b/src/test/java/eu/bitwalker/useragentutils/UtilsTest.java
@@ -1,0 +1,42 @@
+package eu.bitwalker.useragentutils;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class UtilsTest {
+
+    private boolean contains(String a, String b) {
+        return Utils.contains(a, new String[] { b });
+    }
+
+    @Test
+    public void matchesWithVersion() {
+        assertFalse(Utils.matchesWithVersion("foo bar/45 baz", "bar/4"));
+        assertTrue(Utils.matchesWithVersion("foo bar/45 baz", "bar/45"));
+
+        assertTrue(Utils.matchesWithVersion("foo bar/10.20 baz", "bar/10"));
+        assertTrue(Utils.matchesWithVersion("foo bar/10.20 baz", "bar/10.2"));
+        assertTrue(Utils.matchesWithVersion("foo bar/10.20 baz", "bar/10.20"));
+        assertTrue(Utils.matchesWithVersion("foo bar/10.200 baz", "bar/10.20"));
+        assertFalse(Utils.matchesWithVersion("foo bar/10.201 baz", "bar/10.20"));
+
+        assertTrue(Utils.matchesWithVersion("foo bar/1.2.3 baz", "bar/1"));
+        assertTrue(Utils.matchesWithVersion("foo bar/1.2.3 baz", "bar/1.2"));
+        assertTrue(Utils.matchesWithVersion("foo bar/1.2.3 baz", "bar/1.2.3"));
+        assertFalse(Utils.matchesWithVersion("foo bar/1.2.3 baz", "bar/1.2.4"));
+        assertFalse(Utils.matchesWithVersion("foo bar/1.2.3 baz", "bar/1.3"));
+
+    }
+
+    @Test
+    public void contains() {
+        assertTrue(contains("foo", "foo"));
+        assertTrue(contains("foo bar baz", "foo"));
+        assertTrue(contains("foo bar baz", "bar"));
+        assertTrue(contains("foo bar baz", "baz"));
+        assertFalse(contains("foo firefox/45 baz", "firefox/4"));
+        assertTrue(contains("foo firefox/45 baz", "firefox/45"));
+    }
+}

--- a/src/test/java/eu/bitwalker/useragentutils/browser/ChromeParameterizedTest.java
+++ b/src/test/java/eu/bitwalker/useragentutils/browser/ChromeParameterizedTest.java
@@ -63,6 +63,10 @@ public class ChromeParameterizedTest extends AbstractUserAgentParameterizedTest 
 				{
 						"Mozilla/5.0 (Windows NT 5.1) AppleWebKit/535.1 (KHTML, like Gecko) Chrome/14.0.815.0 Safari/535.1",
 						Browser.CHROME14, "14.0.815.0", OperatingSystem.WINDOWS_XP },
+				// chrome48
+				{
+							"Mozilla/5.0 (Windows NT 5.1) AppleWebKit/535.1 (KHTML, like Gecko) Chrome/48.0.815.0 Safari/535.1",
+							Browser.CHROME, "48.0.815.0", OperatingSystem.WINDOWS_XP },
 				// chrome29
 				{
 						"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.65 Safari/537.36",

--- a/src/test/java/eu/bitwalker/useragentutils/browser/FirefoxParameterizedTest.java
+++ b/src/test/java/eu/bitwalker/useragentutils/browser/FirefoxParameterizedTest.java
@@ -56,6 +56,14 @@ public class FirefoxParameterizedTest extends
 				{
 						"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.6; rv:25.0) Gecko/20100101 Firefox/25.0",
 						Browser.FIREFOX25, "25.0", OperatingSystem.MAC_OS_X },
+				// firefox43
+				{
+						"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:43.0) Gecko/20100101 Firefox/43.0",
+						Browser.FIREFOX43, "43.0", OperatingSystem.MAC_OS_X },
+				// firefox49 not known -> should fallback to Browser.FIREFOX
+				{
+							"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:49.0) Gecko/20100101 Firefox/49.0",
+							Browser.FIREFOX, "49.0", OperatingSystem.MAC_OS_X },
 				// firefox3mobile
 				{
 						"Mozilla/5.0 (X11; U; Linux armv7l; en-US; rv:1.9.2a1pre) Gecko/20091127 Firefox/3.5 Maemo Browser 1.5.6 RX-51 N900",


### PR DESCRIPTION
Browser versions are detected by solely checking if a string is contained in the user-agent string, which leads to false matches. The now unknown Firefox 43 is reported as "Firefox 4" because `... firefox/43 ...` contains `firefox/4` which defines Firefox 4.

The match is now made considering numbers at the end of the String to be matched (see `Utils.matchesWithVersion()`).