### PR TITLE
#145: created default constructors for all non-enum classes 

### DIFF
--- a/src/main/java/eu/bitwalker/useragentutils/UserAgent.java
+++ b/src/main/java/eu/bitwalker/useragentutils/UserAgent.java
@@ -69,11 +69,23 @@ public class UserAgent implements Serializable
 {
 	
 	private static final long serialVersionUID = 7025462762784240212L;
-	private OperatingSystem operatingSystem = OperatingSystem.UNKNOWN;
-	private Browser browser = Browser.UNKNOWN;
+	private OperatingSystem operatingSystem;
+	private Browser browser;
 	private int id;
 	private String userAgentString;
 		
+	
+	/**
+	 * This constructor is created for APIs that require default constructor 
+	 * and should never be used directly.
+	 * @deprecated Use {@link #UserAgent(OperatingSystem, Browser)} 
+	 */
+	@Deprecated
+	public UserAgent() 
+	{
+		this(OperatingSystem.UNKNOWN, Browser.UNKNOWN);
+	}
+	
 	public UserAgent(OperatingSystem operatingSystem, Browser browser)
 	{
 		this.operatingSystem = operatingSystem;

--- a/src/main/java/eu/bitwalker/useragentutils/Version.java
+++ b/src/main/java/eu/bitwalker/useragentutils/Version.java
@@ -48,6 +48,16 @@ public class Version implements Comparable<Version> {
 	String majorVersion;
 	String minorVersion;
 	
+	/**
+	 * This constructor is created for APIs that require default constructor 
+	 * and should never be used directly.
+	 * @deprecated Use {@link #Version(String, String, String)} 
+	 */
+	@Deprecated
+	public Version() {
+		// default constructor for APIs that require it (e.g. JSON serialization)
+	}
+
 	public Version(String version, String majorVersion, String minorVersion) {
 		super();
 		this.version = version;


### PR DESCRIPTION
Most of the classes in the project are enums. There are only 2 that are regular classes 
(UserAgent and Version). 

Instances of these classes could be serialized using various APIs that use bean convention. Absense of default constructors prevents this. 

I added default constructors, so now we can serialize instance of UserAgent using (for example) Jackson. 