### PR TITLE
Added getName method to eu.bitwalker.useragentutils.RenderingEngine.

### DIFF
--- a/src/main/java/eu/bitwalker/useragentutils/RenderingEngine.java
+++ b/src/main/java/eu/bitwalker/useragentutils/RenderingEngine.java
@@ -90,4 +90,8 @@ public enum RenderingEngine {
 		this.name = name;
 	}
 
+        public String getName() {
+                return name;
+        }
+
 }


### PR DESCRIPTION
Method getName has been omitted from class eu.bitwalker.useragentutils.RenderingEngine. If that was by mistake, getName method should be added. If not, field name should be removed.
